### PR TITLE
Fix: env asset on gh-pages

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -14,9 +14,7 @@ jobs:
       - uses: SpicyPizza/create-envfile@v1.3
         with:
           file_name: constants.env
-          envkey_BACKEND_API_URL: ${{ secrets.BACKEND_API_URL }}
-          envkey_IS_SAMPLE: ${{ secrets.IS_SAMPLE }}
-          envkey_STOP_ID: ${{ secrets.STOP_ID }}
+          envkey_TEST: "test"
       - uses: bluefireteam/flutter-gh-pages@v7
         with:
           baseHref: /maccas-hot-bbq-sauce-frontend/

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
+      - uses: SpicyPizza/create-envfile@v1.3
+        with:
+          file_name: constants.env
+          envkey_BACKEND_API_URL: ${{ secrets.BACKEND_API_URL }}
+          envkey_IS_SAMPLE: ${{ secrets.IS_SAMPLE }}
+          envkey_STOP_ID: ${{ secrets.STOP_ID }}
       - uses: bluefireteam/flutter-gh-pages@v7
         with:
           baseHref: /maccas-hot-bbq-sauce-frontend/

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,7 @@ import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platf
 import 'package:maccas_sticky_hot_bbq_sauce/widgets/maps/google_maps.dart';
 
 Future main() async {
-  await dotenv.load(fileName: '.env');
+  await dotenv.load(fileName: 'constants.env');
   ApiService.getStopData(ApiConstants.currentStopId);
   runApp(const MyApp());
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,7 +64,7 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
     - assets/images/
-    - .env
+    - constants.env
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
### Description

Renames .env file so it's readable as an asset on gh-pages

### How to test this feature

Will test on deployment
