### PR TITLE
Fix: Add env var for date validating testing constant

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: bluefireteam/flutter-gh-pages@v7
         with:
           baseHref: /maccas-hot-bbq-sauce-frontend/
-          customArgs: --dart-define=BACKEND_API_URL="${{ secrets.BACKEND_API_URL }}" --dart-define=IS_SAMPLE="${{ secrets.IS_SAMPLE }}" --dart-define=STOP_ID="${{ secrets.STOP_ID }}"
+          customArgs: --dart-define=BACKEND_API_URL="${{ secrets.BACKEND_API_URL }}" --dart-define=IS_SAMPLE="${{ secrets.IS_SAMPLE }}" --dart-define=STOP_ID="${{ secrets.STOP_ID }}" --dart-define=DAY_SUBTRACT="${{ secrets.DAY_SUBTRACT }}"

--- a/lib/constants/time_constants.dart
+++ b/lib/constants/time_constants.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class TimeConstants {
+  static int daySubtract = int.parse(
+      const String.fromEnvironment("DAY_SUBTRACT").isNotEmpty
+          ? const String.fromEnvironment("DAY_SUBTRACT")
+          : dotenv.get('DAY_SUBTRACT', fallback: '0'));
+}

--- a/lib/utilities/validate_stop_time_util.dart
+++ b/lib/utilities/validate_stop_time_util.dart
@@ -2,12 +2,14 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:maccas_sticky_hot_bbq_sauce/constants/time_constants.dart';
 import 'package:maccas_sticky_hot_bbq_sauce/models/calendar_model.dart';
 import 'package:maccas_sticky_hot_bbq_sauce/models/exception_model.dart';
 import 'package:maccas_sticky_hot_bbq_sauce/models/stop_time_model.dart';
 
 class ValidateStopTimeUtil {
-  static DateTime now = DateTime.now();
+  static DateTime now =
+      DateTime.now().subtract(Duration(days: TimeConstants.daySubtract));
 
   static bool valid(StopTimeModel stopTime) {
     for (ExceptionModel exception in stopTime.trip!.exceptions ?? []) {
@@ -35,6 +37,10 @@ class ValidateStopTimeUtil {
   }
 
   static bool afterNow(StopTimeModel stopTime) {
-    return stopTime.departure.isAfter(now) ? true : false;
+    return stopTime.departure
+            .subtract(Duration(days: TimeConstants.daySubtract))
+            .isAfter(now)
+        ? true
+        : false;
   }
 }


### PR DESCRIPTION
### Description

Fixes initial stoptime data to throw away passed stop times.

Requires additional DAY_SUBTRACT variable in constants.env

### How to test this feature

Add DAY_SUBTRACT variable in constants.env set it to a arbitrary number like 20
