### PR TITLE
Feat: Add service to fetch from the landmarks endpoint

### DIFF
--- a/lib/constants/api_constants.dart
+++ b/lib/constants/api_constants.dart
@@ -16,6 +16,7 @@ class ApiConstants {
           (isSample ? '/sample' : '');
   static String stopsEndpoint = '/stop';
   static String tripsEndpoint = '/trip';
+  static String landmarksEndpoint = '/landmark';
   static String currentStopId =
       const String.fromEnvironment("STOP_ID").isNotEmpty
           ? const String.fromEnvironment("STOP_ID")

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:maccas_sticky_hot_bbq_sauce/constants/api_constants.dart';
+import 'package:maccas_sticky_hot_bbq_sauce/models/landmark_model.dart';
 import 'package:maccas_sticky_hot_bbq_sauce/models/stop_model.dart';
 import 'package:maccas_sticky_hot_bbq_sauce/models/trip_model.dart';
 import 'package:maccas_sticky_hot_bbq_sauce/widgets/appbar/appbar.dart';
@@ -46,6 +47,7 @@ class _MyHomePageState extends State<MyHomePage> {
   late String _time;
   StopModel? currentStop;
   TripModel? trip;
+  List<LandmarkModel> landmarks = [];
 
   @override
   void initState() {
@@ -62,6 +64,9 @@ class _MyHomePageState extends State<MyHomePage> {
   void _getData() async {
     currentStop = (await ApiService.getStopData(ApiConstants.currentStopId))!;
     inspect(currentStop);
+    landmarks =
+        await ApiService.getLandmarksFromStop(ApiConstants.currentStopId);
+    inspect(landmarks);
   }
 
   @override

--- a/lib/models/landmark_model.dart
+++ b/lib/models/landmark_model.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+List<LandmarkModel> landmarkModelFromJson(String str) =>
+    List<LandmarkModel>.from(
+        json.decode(str).map((landmark) => LandmarkModel.fromJson(landmark)));
+
+class LandmarkModel {
+  String id;
+  LatLng location;
+  String name;
+  String? imgB64;
+  double distance;
+  double? rating;
+  String? iconUrl;
+
+  LandmarkModel({
+    required this.id,
+    required this.location,
+    required this.name,
+    required this.imgB64,
+    required this.distance,
+    required this.rating,
+    required this.iconUrl,
+  });
+
+  factory LandmarkModel.fromJson(Map<String, dynamic> json) => LandmarkModel(
+        id: json['id'],
+        location: LatLng(json['latitude'], json['longitude']),
+        name: json['name'],
+        imgB64: json['image'],
+        distance: json['distance'],
+        rating: json['rating'],
+        iconUrl: json['iconUrl'],
+      );
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:maccas_sticky_hot_bbq_sauce/constants/api_constants.dart';
+import 'package:maccas_sticky_hot_bbq_sauce/models/landmark_model.dart';
 import 'package:maccas_sticky_hot_bbq_sauce/models/stop_model.dart';
 import 'package:maccas_sticky_hot_bbq_sauce/models/trip_model.dart';
 
@@ -37,6 +38,23 @@ class ApiService {
     } catch (e) {
       log(e.toString());
       return null;
+    }
+  }
+
+  static Future<List<LandmarkModel>> getLandmarksFromStop(String stopId) async {
+    try {
+      Uri url = Uri.parse(
+          '${ApiConstants.baseUrl}${ApiConstants.landmarksEndpoint}?stopId=$stopId');
+      var response = await http.get(url);
+      if (response.statusCode == 200) {
+        List<LandmarkModel> model = landmarkModelFromJson(response.body);
+        return model;
+      } else {
+        return [];
+      }
+    } catch (e) {
+      log(e.toString());
+      return [];
     }
   }
 }


### PR DESCRIPTION
### Description

Adds service to enable fetching from the Landmarks endpoint.
Image is in B64 format and requires B64 decoding when displaying to the interface.

### How to test this feature

Check the inspect output from main in the debug console.

<img width="517" alt="Screen Shot 2022-10-17 at 22 39 50" src="https://user-images.githubusercontent.com/18397759/196179257-079ef4d0-7e62-4224-a073-433f64e2709e.png">

